### PR TITLE
Add support for .json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ module.exports = {
     target: '#svelte',
     vite: {
       plugins: [
-        precompileIntl('locales') // if your translations are defined in /locales/[lang].js
-      ]			
+        // if your translations are defined in /locales/[lang].js
+        // also you can change prefix for json files ($locales by default)
+        precompileIntl('locales', '$myprefix')
+      ]
     }
   }
 };
@@ -97,13 +99,15 @@ If you are using CommonJS, you can instead use `const precompileIntl = require("
 From this step onward the library almost identical to use and configure to the popular `svelte-i18n`. It has the same features and only the import path is different. You can check the docs of `svelte-i18n` for examples and details in the configuration options.
 
 4. Now you need some initialization code to register your locales and configure your preferences. You can import your languages statically (which will add them to your bundle) or register loaders that will load the translations lazily. The best place to put this configuration is inside a `<script type="module">` on your `src/$layout.svelte`
-
 ```html
 <script>
   import { addMessages, init, getLocaleFromNavigator /*, register */ } from 'svelte-intl-precompile';
   import en from '../../locales/en.js';
+  // load /locales/es.json if prefix set to '$myprefix'
+  import es from '$myprefix/es.js' // or $myprefix/es.ts for typescript projects
   // @ts-ignore
   addMessages('en', en);
+  addMessages('es', es);
   // register('es', () => import('../../locales/en.js')); <-- use this approach if you want locales to be load lazily
 
   init({

--- a/sveltekit-plugin.cjs
+++ b/sveltekit-plugin.cjs
@@ -23,7 +23,8 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 
 			watcher.on('change', async(file) => {
 				if(file.includes(resolvedPath)){
-					const module = moduleGraph.getModuleById(`${prefix}/${detectLanguageCode(file)}.ts`);
+					const name = `${prefix}/${detectLanguageCode(file)}`
+					const module = moduleGraph.getModuleById(`${name}.ts`) || moduleGraph.getModuleById(`${name}.js`);
 					if (module) {
 						moduleGraph.invalidateModule(module);
 					}

--- a/sveltekit-plugin.cjs
+++ b/sveltekit-plugin.cjs
@@ -20,14 +20,17 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 		name: 'svelte-intl-precompile', // required, will show up in warnings and errors
 		configureServer(server) {
 			const { ws, watcher, moduleGraph } = server
-
+			// listen to vite files watcher
 			watcher.on('change', async(file) => {
+				// check if file changed is a locale
 				if(file.includes(resolvedPath)){
 					const name = `${prefix}/${detectLanguageCode(file)}`
+					// check if locale file is in vite cache
 					const module = moduleGraph.getModuleById(`${name}.ts`) || moduleGraph.getModuleById(`${name}.js`);
 					if (module) {
 						moduleGraph.invalidateModule(module);
 					}
+					// trigger hmr
 					ws.send({ type: 'full-reload', path: '*' })
 				}
 			})

--- a/sveltekit-plugin.cjs
+++ b/sveltekit-plugin.cjs
@@ -1,18 +1,51 @@
 const babel = require('@babel/core');
 const buildPlugin = require("babel-plugin-precompile-intl");
 const path = require('path');
+const fs = require('fs');
 
 const intlPrecompiler = buildPlugin('svelte-intl-precompile');
+
+function detectLanguageCode (filepath) {
+	return path.basename(filepath).split('.')[0]
+}
 
 function transformCode(code) {
 	return babel.transform(code, { plugins: [intlPrecompiler] }).code;
 }
 
-function svelteIntlPrecompile(localesRoot) {  
+function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
+	const resolvedPath = path.resolve(localesRoot)
+
 	return {
-	  	name: 'svelte-intl-precompile', // required, will show up in warnings and errors
-		transform(code, id) {	
-			if (id.includes(path.resolve(localesRoot))) {
+		name: 'svelte-intl-precompile', // required, will show up in warnings and errors
+		configureServer(server) {
+			const { ws, watcher, moduleGraph } = server
+
+			watcher.on('change', async(file) => {
+				if(file.includes(resolvedPath)){
+					const module = moduleGraph.getModuleById(`${prefix}/${detectLanguageCode(file)}.ts`);
+					if (module) {
+						moduleGraph.invalidateModule(module);
+					}
+					ws.send({ type: 'full-reload', path: '*' })
+				}
+			})
+		},
+		resolveId(id) {
+			if (id.startsWith(prefix)) {
+				return id;
+			}
+		},
+		load(id) {
+			if (id.startsWith(prefix)) {
+				const code = fs.readFileSync(path.join(localesRoot, `${detectLanguageCode(id)}.json`), {
+					encoding: 'utf-8'
+				});
+				return transformCode(`export default ${code}`);
+			}
+		},
+		transform(code, id) {
+			if (id.includes(resolvedPath)) {
 				return transformCode(code);
 			}
 		}

--- a/sveltekit-plugin.js
+++ b/sveltekit-plugin.js
@@ -23,7 +23,8 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 
 			watcher.on('change', async(file) => {
 				if(file.includes(resolvedPath)){
-					const module = moduleGraph.getModuleById(`${prefix}/${detectLanguageCode(file)}.ts`);
+					const name = `${prefix}/${detectLanguageCode(file)}`
+					const module = moduleGraph.getModuleById(`${name}.ts`) || moduleGraph.getModuleById(`${name}.js`);
 					if (module) {
 						moduleGraph.invalidateModule(module);
 					}

--- a/sveltekit-plugin.js
+++ b/sveltekit-plugin.js
@@ -1,18 +1,51 @@
 import babel from '@babel/core';
 import buildPlugin from 'babel-plugin-precompile-intl';
 import path from 'path';
+import fs from 'fs';
 
 const intlPrecompiler = buildPlugin('svelte-intl-precompile');
+
+function detectLanguageCode (filepath) {
+	return path.basename(filepath).split('.')[0]
+}
 
 function transformCode(code) {
 	return babel.transform(code, { plugins: [intlPrecompiler] }).code;
 }
 
-function svelteIntlPrecompile(localesRoot) {  
+function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
+	const resolvedPath = path.resolve(localesRoot)
+
 	return {
-	  	name: 'svelte-intl-precompile', // required, will show up in warnings and errors
-		transform(code, id) {	
-			if (id.includes(path.resolve(localesRoot))) {
+		name: 'svelte-intl-precompile', // required, will show up in warnings and errors
+		configureServer(server) {
+			const { ws, watcher, moduleGraph } = server
+
+			watcher.on('change', async(file) => {
+				if(file.includes(resolvedPath)){
+					const module = moduleGraph.getModuleById(`${prefix}/${detectLanguageCode(file)}.ts`);
+					if (module) {
+						moduleGraph.invalidateModule(module);
+					}
+					ws.send({ type: 'full-reload', path: '*' })
+				}
+			})
+		},
+		resolveId(id) {
+			if (id.startsWith(prefix)) {
+				return id;
+			}
+		},
+		load(id) {
+			if (id.startsWith(prefix)) {
+				const code = fs.readFileSync(path.join(localesRoot, `${detectLanguageCode(id)}.json`), {
+					encoding: 'utf-8'
+				});
+				return transformCode(`export default ${code}`);
+			}
+		},
+		transform(code, id) {
+			if (id.includes(resolvedPath)) {
 				return transformCode(code);
 			}
 		}

--- a/sveltekit-plugin.js
+++ b/sveltekit-plugin.js
@@ -20,14 +20,17 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 		name: 'svelte-intl-precompile', // required, will show up in warnings and errors
 		configureServer(server) {
 			const { ws, watcher, moduleGraph } = server
-
+			// listen to vite files watcher
 			watcher.on('change', async(file) => {
+				// check if file changed is a locale
 				if(file.includes(resolvedPath)){
 					const name = `${prefix}/${detectLanguageCode(file)}`
+					// check if locale file is in vite cache
 					const module = moduleGraph.getModuleById(`${name}.ts`) || moduleGraph.getModuleById(`${name}.js`);
 					if (module) {
 						moduleGraph.invalidateModule(module);
 					}
+					// trigger hmr
 					ws.send({ type: 'full-reload', path: '*' })
 				}
 			})


### PR DESCRIPTION
By default it handles `$locales/en.ts` import, reads contents of `en.json` file and precompile it on the fly.
Live reload supported too.

svelte.config.js:
```js
precompileIntl('src/locales', '$locales')
```

__layout.svelte:
```js
import en from '$locales/en.ts';
```

src/locales/en.json:
```json
{"foot": "Test {count} {count, plural, =1 {foot} other {feet}}"}
```