### PR TITLE
Reexport type definitions in d.ts file to enable typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export * from 'precompile-intl-runtime';


### PR DESCRIPTION
Typescript types are now lost due to reexport from js file, here I'm also adding .d.ts file to reexport type info without build step. 