### PR TITLE
feat: auto register all available locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.7.0
+- [FEATURE] expose the `prefix` (default: `$locales`) as a module that allows to register (`registerAll()`) and access (`availableLocales`) all available translations.
 ## 0.6.2
 - [BUGFIX] Update babel pluging to fix a bug with translations that only contain a single date/time helper and no other text.
 - ## 0.6.1

--- a/README.md
+++ b/README.md
@@ -179,3 +179,25 @@ Then you can use the `session` store to pass it to the `init` function:
   }
 </script>
 ```
+
+If you have a lot of languages or want to register all available languages, you can use the `registerAll` function:
+
+```html
+<!-- __layout.svelte -->
+<script context="module">
+  import { register, init, waitLocale, getLocaleFromNavigator } from 'svelte-intl-precompile';
+  import { registerAll } from '$locales';
+
+  // Equivalent to a `register("lang", () => import('$locales/lang.js'))` fro each json lang file in localesRoot.
+  registerAll();
+
+  export async function load({session}) {
+    init({
+      fallbackLocale: 'en',
+      initialLocale: session.acceptedLanguage || getLocaleFromNavigator(),
+    });
+    await waitLocale(); // awaits for initialLocale language pack to finish loading;
+    return {};
+  }
+</script>
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,9 @@
 export * from 'precompile-intl-runtime';
+
+declare module '$locales' {
+  export * from 'precompile-intl-runtime'
+
+  const availableLocales: string[]
+
+  export default availableLocales
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 export * from 'precompile-intl-runtime';
 
 declare module '$locales' {
-  export * from 'precompile-intl-runtime'
+  /** Registers all locales found in `localesRoot`. */
+  export const registerAll: () => void
 
-  const availableLocales: string[]
-
-  export default availableLocales
+  /** A list of all locales that will be registered by {@link registerAll()}. */
+  export const availableLocales: string[]
 }

--- a/sveltekit-plugin.cjs
+++ b/sveltekit-plugin.cjs
@@ -18,6 +18,7 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 
 	return {
 		name: 'svelte-intl-precompile', // required, will show up in warnings and errors
+		enforce: 'pre',
 		configureServer(server) {
 			const { ws, watcher, moduleGraph } = server
 			// listen to vite files watcher
@@ -36,11 +37,41 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 			})
 		},
 		resolveId(id) {
-			if (id.startsWith(prefix)) {
+			if (id === prefix || id.startsWith(prefix + '/')) {
 				return id;
 			}
 		},
 		load(id) {
+			// auto register locales by importing $locale module
+			if (id === prefix) {
+				const code = [
+					`import { get } from 'svelte/store'`,
+					`import { register, locales } from 'precompile-intl-runtime'`,
+					// act as an alias for all helper functions
+					// import { t } from '$locales'
+					`export * from 'precompile-intl-runtime'`
+				]
+
+				// add register calls for each found locale
+				for (const file of fs.readdirSync(localesRoot)) {
+					if (path.extname(file) === '.json') {
+						const locale = path.basename(file, '.json')
+
+						code.push(
+							`register(${JSON.stringify(locale)}, () => import(${
+								JSON.stringify(`${prefix}/${locale}.js`)
+							}))`,
+						)
+					}
+				}
+
+				// the default export can be used to get a list of all registered locales
+				// import registeredLocales from '$locales'
+				code.push(`export default /* @__PURE__ */ get(locales)`)
+
+				return code.join('\n')
+			}
+
 			if (id.startsWith(prefix)) {
 				const code = fs.readFileSync(path.join(localesRoot, `${detectLanguageCode(id)}.json`), {
 					encoding: 'utf-8'

--- a/sveltekit-plugin.cjs
+++ b/sveltekit-plugin.cjs
@@ -45,7 +45,7 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 			// allow to auto register locales by calling registerAll from $locales module
 			if (id === prefix) {
 				const code = [
-					`import { register } from 'precompile-intl-runtime'`,
+					`import { register } from 'svelte-intl-precompile'`,
 					`export function registerAll() {`
 				]
 

--- a/sveltekit-plugin.js
+++ b/sveltekit-plugin.js
@@ -45,7 +45,7 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 			// allow to auto register locales by calling registerAll from $locales module
 			if (id === prefix) {
 				const code = [
-					`import { register } from 'precompile-intl-runtime'`,
+					`import { register } from 'svelte-intl-precompile'`,
 					`export function registerAll() {`
 				]
 

--- a/sveltekit-plugin.js
+++ b/sveltekit-plugin.js
@@ -18,6 +18,7 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 
 	return {
 		name: 'svelte-intl-precompile', // required, will show up in warnings and errors
+		enforce: 'pre',
 		configureServer(server) {
 			const { ws, watcher, moduleGraph } = server
 			// listen to vite files watcher
@@ -36,12 +37,42 @@ function svelteIntlPrecompile(localesRoot, prefix = '$locales') {
 			})
 		},
 		resolveId(id) {
-			if (id.startsWith(prefix)) {
+			if (id === prefix || id.startsWith(prefix + '/')) {
 				return id;
 			}
 		},
 		load(id) {
-			if (id.startsWith(prefix)) {
+			// auto register locales by importing $locale module
+			if (id === prefix) {
+				const code = [
+					`import { get } from 'svelte/store'`,
+					`import { register, locales } from 'precompile-intl-runtime'`,
+					// act as an alias for all helper functions
+					// import { t } from '$locales'
+					`export * from 'precompile-intl-runtime'`
+				]
+
+				// add register calls for each found locale
+				for (const file of fs.readdirSync(localesRoot)) {
+					if (path.extname(file) === '.json') {
+						const locale = path.basename(file, '.json')
+
+						code.push(
+							`register(${JSON.stringify(locale)}, () => import(${
+								JSON.stringify(`${prefix}/${locale}.js`)
+							}))`,
+						)
+					}
+				}
+
+				// the default export can be used to get a list of all registered locales
+				// import registeredLocales from '$locales'
+				code.push(`export default /* @__PURE__ */ get(locales)`)
+
+				return code.join('\n')
+			}
+
+			if (id.startsWith(prefix + '/')) {
 				const code = fs.readFileSync(path.join(localesRoot, `${detectLanguageCode(id)}.json`), {
 					encoding: 'utf-8'
 				});


### PR DESCRIPTION
The `prefix` (`$locales`) is exposed as a module and can be used to auto register all available translations.

```js
import { init, waitLocale } from '$locales':

init({ initialLocale: en });

export async function preload() {
  return waitLocale(); // awaits the default locale, "en" in this case.
}
```

The generated module has a default export to retrieve a list of all available locales. This can be used to select an available language.

```js
import registeredLocales, { getPossibleLocales } from '$locales'

// acceptedLanguages could have been parsed 'accept-language' header or navigator.languages
function detectPreferredLocale(acceptedLanguages) {
  // first try the exact matches
  for (const language of acceptedLanguages) {
    if (registeredLocales.includes(language)) {
      return language
    }
  }

  // then try possible locales
  for (const language of acceptedLanguages) {
    for (const locale of getPossibleLocales(language)) {
      if (registeredLocales.includes(locale)) {
        return locale
      }
    }
  }

  // fallback
  return 'en'
}
```

In the future I would like to use module augmentation to generate typescript types for `$locales`.  This would allow type checked access to `$format`.

---

For the following files:

```
<localsRoot>/de.json
<localsRoot>/en.json
<localsRoot>/es.json
```

The `$locales` module would look like:

```js
import { get } from 'svelte/store'
import { register, locales } from 'precompile-intl-runtime'

export * from 'precompile-intl-runtime'

register("de", () => import('$locales/de.js'))
register("en", () => import('$locales/en.js'))
register("es", () => import('$locales/es.js'))

export default /* @__PURE__ */ get(locales)
```
