### PR TITLE
Fix import of `$locales` from Typescript project

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
-export * from 'precompile-intl-runtime';
+declare module 'svelte-intl-precompile' {
+  export * from 'precompile-intl-runtime';
+}
 
 declare module '$locales' {
   /** Registers all locales found in `localesRoot`. */


### PR DESCRIPTION
A top-level export in `index.d.ts` was preventing Typescript from using typings for `$locales` when imported from a Typescript project.

This PR fixes this by putting the export in a module declaration.